### PR TITLE
Added readmore.html in _includes and used blog index and post template

### DIFF
--- a/_includes/readmore.html
+++ b/_includes/readmore.html
@@ -1,0 +1,15 @@
+					{% for post in site.posts limit: 4 %}
+							<div class="recent-top">
+								<div class="col-md-4 recent-left">
+									<img src="/assets/recent-1.jpg" alt="">
+								</div> <!-- End col-md-4 recent-left -->
+								<div class="col-md-8 recent-left">
+									<span>{{ post.date | date: "%b %-d, %Y" }}</span>
+									<a href="{{ post.url }}"><h5>{{ post.title }}</h5></a>
+									<p>{{ post.content | truncatewords: 20 | strip_html }}</p>
+								</div> <!-- End col-md-8 recent-left -->
+								<div class="clearfix"></div>
+							</div> <!-- End recent-top -->
+					{% endfor %}
+						</div><!-- End recent -->
+					</div><!-- end col-md-4 blog-right -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,22 +29,7 @@ layout: default
 
 						<div class="recent">
 							<h4>Recent posts</h4>
-							
-					{% for post in site.posts limit: 4 %}
-							<div class="recent-top">
-								<div class="col-md-4 recent-left">
-									<img src="/assets/recent-1.jpg" alt="">
-								</div> <!-- End col-md-4 recent-left -->
-								<div class="col-md-8 recent-left">
-									<span>{{ post.date | date: "%b %-d, %Y" }}</span>
-									<a href="{{ post.url }}"><h5>{{ post.title }}</h5></a>
-									<p>{{ post.content | truncatewords: 20 | strip_html }}</p>
-								</div> <!-- End col-md-8 recent-left -->
-								<div class="clearfix"></div>
-							</div> <!-- End recent-top -->
-					{% endfor %}
-						</div><!-- End recent -->
-					</div><!-- end col-md-4 blog-right -->
+					{% include readmore.html %}
 					<div class="clearfix"></div>
 				</div> <!-- End blog-top -->
 				<div class="blog-bottom">

--- a/blog/index.html
+++ b/blog/index.html
@@ -37,22 +37,7 @@ comments: true
 
 						<div class="recent">
 							<h4>Recent posts</h4>
-							
-					{% for post in site.posts limit: 4 %}
-							<div class="recent-top">
-								<div class="col-md-4 recent-left">
-									<img src="/assets/recent-1.jpg" alt="">
-								</div> <!-- End col-md-4 recent-left -->
-								<div class="col-md-8 recent-left">
-									<span>{{ post.date | date: "%b %-d, %Y" }}</span>
-									<a href="{{ post.url }}"><h5>{{ post.title }}</h5></a>
-									<p>{{ post.content | truncatewords: 20 | strip_html }}</p>
-								</div> <!-- End col-md-8 recent-left -->
-								<div class="clearfix"></div>
-							</div> <!-- End recent-top -->
-					{% endfor %}
-						</div><!-- End recent -->
-					</div><!-- end col-md-4 blog-right -->
+              {% include readmore.html %}							
 					<div class="clearfix"></div>
 				</div> <!-- End blog-top -->
 				<div class="blog-bottom">


### PR DESCRIPTION
This PR covers the following changes:
- I've cut out all the code that makes up the read more section of the sidebar used in blog index and post layout.
- I moved it to its own file in the _includes directory and then edited blog index and post layout to use this.

This way when we make changes to the read more function in the sidebar we can change it in one place instead of two.

I already did this with head, header, footer, pagination and archives, so just tidying up really.
